### PR TITLE
Rename navigator, disable header for root stack header

### DIFF
--- a/App.js
+++ b/App.js
@@ -13,9 +13,9 @@ import {NavigationContainer} from '@react-navigation/native';
 import {createStackNavigator} from '@react-navigation/stack';
 import {useReduxDevToolsExtension} from '@react-navigation/devtools';
 
-import {createSurfNavigator} from './src/createSurfNavigator';
+import {createSurfSplitNavigator} from './src/createSurfNavigator';
 
-const Surf = createSurfNavigator();
+const SurfSplit = createSurfSplitNavigator();
 
 const Main = ({navigation}) => (
   <View>
@@ -55,11 +55,11 @@ const App: () => React$Node = () => {
 
   return (
     <NavigationContainer ref={navRef} linking={['/']}>
-      <Surf.Navigator initialRouteName="first">
-        <Surf.Screen name="main" component={Main} />
-        <Surf.Screen name="first" component={Detail1} />
-        <Surf.Screen name="second" component={Detail2} />
-      </Surf.Navigator>
+      <SurfSplit.Navigator initialRouteName="first">
+        <SurfSplit.Screen name="main" component={Main} />
+        <SurfSplit.Screen name="first" component={Detail1} />
+        <SurfSplit.Screen name="second" component={Detail2} />
+      </SurfSplit.Navigator>
     </NavigationContainer>
   );
 };

--- a/src/SurfRouter.js
+++ b/src/SurfRouter.js
@@ -7,7 +7,7 @@ export const setIsSplitted = s => {
   isSplitted = s;
 };
 
-export function SurfRouter(options) {
+export function SurfSplitRouter(options) {
   const tabRouter = TabRouter(options);
   const stackRouter = StackRouter(options);
   const router = {

--- a/src/createSurfNavigator.js
+++ b/src/createSurfNavigator.js
@@ -16,7 +16,7 @@ import {
 import {StackView} from '@react-navigation/stack';
 import ResourceSavingScene from '@react-navigation/bottom-tabs/lib/module/views/ResourceSavingScene';
 
-import {SurfRouter, setIsSplitted} from './SurfRouter';
+import {SurfSplitRouter, setIsSplitted} from './SurfRouter';
 
 const tabStateToStackOne = ({history, ...rest}) => {
   const {index} = rest;
@@ -30,26 +30,36 @@ const tabStateToStackOne = ({history, ...rest}) => {
 
 const getIsSplitted = ({width}) => width > 600;
 
-export const SurfNavigator = ({children, initialRouteName, screenOptions}) => {
+export const SurfSplitNavigator = ({
+  children,
+  initialRouteName,
+  screenOptions,
+}) => {
   const dimensions = useWindowDimensions();
   const isSplitted = getIsSplitted(dimensions);
   setIsSplitted(isSplitted);
 
   let mainScreen;
 
-  const {state, navigation, descriptors} = useNavigationBuilder(SurfRouter, {
-    children: isSplitted
-      ? React.Children.toArray(children).filter(child => {
-          if (child.props.name !== 'main') {
-            return true;
-          }
-          mainScreen = child.props.component;
-          return false;
-        })
-      : children,
-    initialRouteName: isSplitted ? initialRouteName : 'main',
-    screenOptions,
-  });
+  const {state, navigation, descriptors} = useNavigationBuilder(
+    SurfSplitRouter,
+    {
+      children: isSplitted
+        ? React.Children.toArray(children).filter(child => {
+            if (child.props.name !== 'main') {
+              return true;
+            }
+            mainScreen = child.props.component;
+            return false;
+          })
+        : children,
+      initialRouteName: isSplitted ? initialRouteName : 'main',
+      screenOptions: {
+        ...screenOptions,
+        headerShown: false,
+      },
+    },
+  );
 
   const loadedRef = React.useRef([]);
 
@@ -99,7 +109,9 @@ export const SurfNavigator = ({children, initialRouteName, screenOptions}) => {
   );
 };
 
-export const createSurfNavigator = createNavigatorFactory(SurfNavigator);
+export const createSurfSplitNavigator = createNavigatorFactory(
+  SurfSplitNavigator,
+);
 
 const styles = StyleSheet.create({
   body: {


### PR DESCRIPTION
There was a problem, that by default we have a header for root stack, and that header is conflicting with a nested one, for example when you tap back after some chain of calls in nested stack, you still will go to main. Disabling header for root one solved it, as now it's nested shown.