### PR TITLE
ensure initial route in the history

### DIFF
--- a/src/SurfSplitRouter.js
+++ b/src/SurfSplitRouter.js
@@ -268,6 +268,29 @@ export const SurfSplitRouter: RouterFactory<
                 if (newState == null) {
                     return null;
                 }
+
+                // Ensure the history always includes the initial route
+                const initialRoute = state.routes.find(
+                    ({ name }) => name === initialRouteName,
+                );
+
+                if (initialRoute) {
+                    // Check if the history contains initial route already
+                    if (
+                        !newState.history ||
+                        !newState.history.find(
+                            // $FlowFixMe
+                            ({ key }) => key === initialRoute.key,
+                        )
+                    ) {
+                        // $FlowFixMe
+                        newState.history = [
+                            // Add the initial route to the beginning of the history if not
+                            { type: 'route', key: initialRoute.key },
+                            ...(newState.history || []),
+                        ];
+                    }
+                }
             }
 
             // $FlowFixMe

--- a/src/SurfSplitRouter.js
+++ b/src/SurfSplitRouter.js
@@ -270,24 +270,25 @@ export const SurfSplitRouter: RouterFactory<
                 }
 
                 // Ensure the history always includes the initial route
-                const initialRoute = state.routes.find(
-                    ({ name }) => name === initialRouteName,
-                );
-
-                if (initialRoute) {
-                    // Check if the history contains initial route already
+                // N.B. This is mostly important for tab router as it might loose the initial route
+                const { history } = newState;
+                if (history) {
+                    // Check if the history contains the initial route already
+                    const initialRoute = state.routes.find(
+                        ({ name }) => name === initialRouteName,
+                    );
                     if (
-                        !newState.history ||
-                        !newState.history.find(
+                        initialRoute &&
+                        !history.find(
                             // $FlowFixMe
                             ({ key }) => key === initialRoute.key,
                         )
                     ) {
+                        // Add the initial route to the beginning of the history if not
                         // $FlowFixMe
                         newState.history = [
-                            // Add the initial route to the beginning of the history if not
                             { type: 'route', key: initialRoute.key },
-                            ...(newState.history || []),
+                            ...history,
                         ];
                     }
                 }


### PR DESCRIPTION
This one is a possible fix for: https://www.notion.so/tonlabs/react-navigation-surf-is-changing-it-s-initial-screen-in-Split-View-on-tablets-2756114e6a024986870a9b570d5cd4a1